### PR TITLE
Bugfix: remove unnecessary js bundle pulls

### DIFF
--- a/webviz.html
+++ b/webviz.html
@@ -4,10 +4,6 @@
 <head>
   <meta charset="utf-8" />
 
-  <script type="text/javascript"
-    src="http://static.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js"></script>
-  <script type="text/javascript" src="http://static.robotwebtools.org/roslibjs/current/roslib.min.js"></script>
-
   <style>
     body {
       margin: 0;


### PR DESCRIPTION
removes script tags that pull in js bundles that are not necessary. recent outage of source links caused webviz to not load.